### PR TITLE
Rename to strong-swagger-client

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,14 @@
 # Swagger JavaScript library
 
-[![Build Status](https://api.travis-ci.org/swagger-api/swagger-js.png?branch=master)](https://travis-ci.org/swagger-api/swagger-js)
+[![Build Status](https://api.travis-ci.org/strongloop/strong-swagger-js.png?branch=master)](https://travis-ci.org/strongloop/strong-swagger-js)
 
+This repository contains a friendly fork
+of [swagger-js](https://github.com/swagger-api/swagger-js) v2.0.x with
+additional enhancements. Our goal is to eventually contribute these
+improvements to the upstream repository.
 
-This is the Wordnik Swagger JavaScript client for use with [Swagger](http://swagger.io)-enabled APIs. It's written in pure javascript and tested with mocha, and is the fastest way to enable a JavaScript client to communicate with a Swagger-enabled server.
-
-## What's Swagger?
-
-The goal of Swagger™ is to define a standard, language-agnostic interface to REST APIs which allows both humans and computers to discover and understand the capabilities of the service without access to source code, documentation, or through network traffic inspection. When properly defined via Swagger, a consumer can understand and interact with the remote service with a minimal amount of implementation logic. Similar to what interfaces have done for lower-level programming, Swagger removes the guesswork in calling the service.
-
-
-Check out [Swagger-Spec](https://github.com/swagger-api/swagger-spec) for additional information about the Swagger project, including additional libraries with support for other languages and more.
-
-
-## Compatability
-The Swagger Specification has undergone 3 revisions since initial creation in 2010.  The swagger-js project has the following compatibilies with the Swagger specification:
-
-Swagger JS Version      | Release Date | Swagger Spec compatability | Notes
------------------------ | ------------ | -------------------------- | -----
-2.1.0 (in development)  | n/a          |      2.0      | [branch develop_2.0](https://github.com/swagger-api/swagger-js/tree/develop_2.0)
-2.0.41                  | 2014-09-18   | 1.1, 1.2      | [tag v2.0.41](https://github.com/swagger-api/swagger-js/tree/v2.0.41)
-1.0.4                   | 2013-06-26   | 1.0, 1.1, 1.2 | [tag v1.0.4](https://github.com/swagger-api/swagger-js/tree/v1.0.4)
+The client is compatible with Swagger Spec versions 1.1 and 1.2, the Swagger
+Spec version 2.0 is *not* supported by this module.
 
 ### Calling an API with Swagger + Node.js!
 
@@ -188,8 +176,9 @@ The HTTP requests themselves are handled by the excellent [shred](https://github
 Development
 -----------
 
-Please [fork the code](https://github.com/swagger-api/swagger-js) and help us improve
-swagger.js.
+The original Swagger.js client was written in CoffeeScript
+and was transpiled from develop_2.0 branch. This fork is maintaining the
+transpiled files only.
 
 Running the tests
 ```bash

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "swagger-client",
+  "name": "strong-swagger-client",
   "author": "Zeke Sikelianos <zeke@sikelianos.com>",
-  "contributors": [ 
+  "contributors": [
     {
       "name": "Tony Tam",
       "email": "fehguy@gmail.com"
@@ -12,7 +12,7 @@
   "homepage": "http://swagger.io",
   "repository": {
     "type": "git",
-    "url": "git://github.com/swagger-api/swagger-js.git"
+    "url": "git://github.com/strongloop/strong-swagger-js.git"
   },
   "main": "lib/swagger.js",
   "scripts": {
@@ -32,5 +32,5 @@
     "should": "4.4.2",
     "uglify-js": "1.3.x"
   },
-  "license": "apache 2.0"
+  "license": "Apache-2.0"
 }


### PR DESCRIPTION
Update package.json with the new name.

Edit README.md, describe the purpose (and status) of this fork, remove
bits that are not relevant.

Fix license spec in package.json to use a valid SPDX id.

Connect to strongloop-internal/scrum-loopback#112

@altsang please review
