### PR TITLE
Normalize array values of text properties

### DIFF
--- a/lib/swagger.js
+++ b/lib/swagger.js
@@ -68,6 +68,11 @@
     };
   }
 
+  function normalizeTextValue(value) {
+    return Object.prototype.toString.call(value) === '[object Array]' ?
+      value.join('\n') : value;
+  }
+
   Object.keys = Object.keys || (function () {
     var hasOwnProperty = Object.prototype.hasOwnProperty,
       hasDontEnumBug = !{ toString: null }.propertyIsEnumerable('toString'),
@@ -208,6 +213,7 @@
     this.authSchemes = response.authorizations;
     if (response.info != null) {
       this.info = response.info;
+      this.info.description = normalizeTextValue(this.info.description);
     }
     var isApi = false;
     var i;
@@ -369,7 +375,7 @@
     this.api = api;
     this.swaggerRequstHeaders = api.swaggerRequstHeaders;
     this.path = this.api.resourcePath != null ? this.api.resourcePath : resourceObj.path;
-    this.description = resourceObj.description;
+    this.description = normalizeTextValue(resourceObj.description);
     this.authorizations = (resourceObj.authorizations || {});
 
     var parts = this.path.split('/');
@@ -751,14 +757,25 @@
     this.path = (path || errors.push('SwaggerOperation ' + nickname + ' is missing path.'));
     this.method = (method || errors.push('SwaggerOperation ' + nickname + ' is missing method.'));
     this.parameters = parameters != null ? parameters : [];
-    this.summary = summary;
-    this.notes = notes;
+    for (var ix = 0; ix < parameters.length; ix++) {
+      var param = this.parameters[ix];
+      param.description = normalizeTextValue(param.description);
+    }
+
+    this.summary = normalizeTextValue(summary);
+    this.notes = normalizeTextValue(notes);
     this.type = type;
     this.responseMessages = (responseMessages || []);
     this.resource = (resource || errors.push('Resource is required'));
     this.consumes = consumes;
     this.produces = produces;
     this.authorizations = typeof authorizations !== 'undefined' ? authorizations : resource.authorizations;
+    if (this.authorizations && this.authorizations.oauth2) {
+      var oauth2 = this.authorizations.oauth2;
+      for (var ix = 0; ix < oauth2.length; ix++)
+        oauth2[ix].description = normalizeTextValue(oauth2[ix].description);
+    }
+
     this.deprecated = deprecated;
     this['do'] = __bind(this['do'], this);
 
@@ -810,13 +827,13 @@
           var v = enumValue[j];
           if (param.defaultValue != null) {
             param.allowableValues.descriptiveValues.push({
-              value: String(v),
+              value: String(normalizeTextValue(v)),
               isDefault: (v === param.defaultValue)
             });
           }
           else {
             param.allowableValues.descriptiveValues.push({
-              value: String(v),
+              value: String(normalizeTextValue(v)),
               isDefault: false
             });
           }
@@ -834,13 +851,13 @@
               var v = param.allowableValues.values[j];
               if (param.defaultValue != null) {
                 param.allowableValues.descriptiveValues.push({
-                  value: String(v),
+                  value: String(normalizeTextValue(v)),
                   isDefault: (v === param.defaultValue)
                 });
               }
               else {
                 param.allowableValues.descriptiveValues.push({
-                  value: String(v),
+                  value: String(normalizeTextValue(v)),
                   isDefault: false
                 });
               }

--- a/test/spec/api-docs.json
+++ b/test/spec/api-docs.json
@@ -12,7 +12,7 @@
     },
     {
       "path": "http://localhost:8000/store",
-      "description": "Operations about store"
+      "description": ["Operations about store", "line2"]
     }
   ],
     "authorizations": {
@@ -51,7 +51,11 @@
   },
   "info": {
     "title": "Swagger Sample App",
-    "description": "This is a sample server Petstore server.  You can find out more about Swagger \n    at <a href=\"http://swagger.io\">http://swagger.io</a> or on irc.freenode.net, #swagger.  For this sample,\n    you can use the api key \"special-key\" to test the authorization filters",
+    "description": [
+      "This is a sample server Petstore server.  You can find out more about Swagger ",
+"    at <a href=\"http://swagger.io\">http://swagger.io</a> or on irc.freenode.net, #swagger.  For this sample,",
+"    you can use the api key \"special-key\" to test the authorization filters"
+    ],
     "termsOfServiceUrl": "http://helloreverb.com/terms/",
     "contact": "apiteam@wordnik.com",
     "license": "Apache 2.0",

--- a/test/spec/store
+++ b/test/spec/store
@@ -12,15 +12,18 @@
       "operations": [
         {
           "method": "GET",
-          "summary": "Find purchase order by ID",
-          "notes": "For valid response try integer IDs with value <= 5. Anything above 5 or nonintegers will generate API errors",
+          "summary": ["Find purchase order by ID", "(dummy line)"],
+          "notes": [
+            "For valid response try integer IDs with value <= 5.",
+            "Anything above 5 or nonintegers will generate API errors"
+          ],
           "type": "Order",
           "nickname": "getOrderById",
           "authorizations": {},
           "parameters": [
             {
               "name": "orderId",
-              "description": "ID of pet that needs to be fetched",
+              "description": ["ID of pet that needs to be fetched", "line2"],
               "required": true,
               "type": "string",
               "paramType": "path"
@@ -47,7 +50,7 @@
             "oauth2": [
               {
                 "scope": "test:anything",
-                "description": "anything"
+                "description": ["anything", "another line"]
               }
             ]
           },


### PR DESCRIPTION
Allow Swagger producers to send text properties like "description" and "notes" as an array of strings.

This patch is a different implementation of shelbys/swagger-ui@95ae3c6, shelbys/swagger-ui@a9abc66. IMO, this kind of data manipulation does not belong to views (HTML templates), therefore I made the necessary changes in the "Model" part of MVC.

BTW loopback-explorer is already joining arrays when producing Swagger, but @shelbys pointed out that they'd like to have this feature available for teams that are not using LoopBack (see https://github.com/shelbys/swagger-ui/commit/95ae3c6a2ddabe864afb3839a7ae77c74f923dbb#commitcomment-12051508)

Connect to strongloop-internal/scrum-loopback#112

/to @raymondfeng or @ritch please review
