### PR TITLE
Run browser test as part of `npm test`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,3 @@ script:
   - sh -e /etc/init.d/xvfb start
   - npm install
   - npm test
-  - npm run browsertest

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -111,6 +111,16 @@ gulp.task('watch', ['test'], function () {
 });
 
 gulp.task('browsertest', function(done) {
+  console.log('Build environment');
+  console.log('    CI', process.env.CI);
+  console.log('    DISPLAY', process.env.DISPLAY);
+  if (process.env.CI && !process.env.DISPLAY) {
+    // skip browser tests
+    console.error('Running on CI but DISPLAY is NOT provided.');
+    console.error('Skipping all browser tests.');
+    return done();
+  }
+
   karma.start(karmaConfig, done);
 });
 

--- a/package.json
+++ b/package.json
@@ -19,8 +19,7 @@
     "prepublish": "gulp build",
     "build": "gulp build",
     "dev": "gulp watch",
-    "test": "gulp test",
-    "browsertest": "gulp browsertest"
+    "test": "gulp test && gulp browsertest"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
Rework `npm test` to run browsertests too, so that StrongLoop's Jenkins CI can run these tests too.

Connect to strongloop-internal/scrum-loopback#412
Connect to strongloop/loopback-explorer#54

R=@rmg
